### PR TITLE
Improve AMPL integration in GUI

### DIFF
--- a/python/gui.py
+++ b/python/gui.py
@@ -76,12 +76,17 @@ def parse_lkh_tour(tour_file, cities):
 
 
 def run_ampl(output, csv_path):
-    # Ruta al ejecutable de AMPL
-    ampl_path = r"D:\DEV\AMPL\ampl.exe"
-    
-    # Verificar si el archivo ejecutable existe
-    if not os.path.exists(ampl_path):
-        append_output(output, f"Error: No se encontró el ejecutable de AMPL en {ampl_path}\n")
+    """Execute the AMPL model and display the resulting routes."""
+    # Allow configuration via the AMPL_PATH environment variable.  If not
+    # provided, fall back to searching ``ampl`` in the PATH.
+    ampl_path = os.environ.get("AMPL_PATH", "ampl")
+
+    # Verificar si el archivo ejecutable existe o está en PATH
+    if not shutil.which(ampl_path):
+        append_output(
+            output,
+            f"Error: No se encontró el ejecutable de AMPL ({ampl_path}).\n",
+        )
         return
     
     # Obtener la ruta base del proyecto
@@ -128,20 +133,26 @@ def run_ampl(output, csv_path):
             check=True
         )
         
-        # Mostrar resultados
+        # Mostrar resultados crudos
         append_output(output, "\n=== RESULTADOS DE AMPL ===\n")
         append_output(output, result.stdout)
-        
+
         if result.stderr:
             append_output(output, "\n=== ADVERTENCIAS ===\n")
             append_output(output, result.stderr)
-            
-        # Intentar cargar las ciudades y mostrar las rutas
+
+        # Cargar las ciudades y mostrar las rutas
         try:
             cities = load_cities(csv_path.get())
             routes = parse_ampl_routes(result.stdout, cities)
             if routes:
+                append_output(output, "\nRutas encontradas:\n")
+                for i, route in enumerate(routes, 1):
+                    path = " -> ".join(str(c.idx) for c in route)
+                    append_output(output, f"Vendedor {i}: {path}\n")
                 plot_routes(routes)
+            else:
+                append_output(output, "No se pudieron interpretar rutas en la salida de AMPL\n")
         except Exception as e:
             append_output(output, f"\nError al mostrar las rutas: {str(e)}\n")
             


### PR DESCRIPTION
## Summary
- make AMPL path configurable via `AMPL_PATH` or PATH lookup
- show parsed salesmen routes after running AMPL

## Testing
- `python -m py_compile python/gui.py`
- `python -m py_compile python/heuristica_bmtsp.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685096d0ea348323b0be13a7fcf81e39