### PR TITLE
Improve AMPL integration in GUI

### DIFF
--- a/python/gui.py
+++ b/python/gui.py
@@ -16,16 +16,53 @@ def append_output(widget, text):
 
 
 def parse_ampl_routes(ampl_text, cities):
-    """Parse routes from AMPL output displaying x[s,i,j] variables."""
+    """Parse salesman routes from AMPL ``display x`` output.
+
+    AMPL may print ``x`` either as individual assignments ``x[s,i,j] = 1`` or as
+    matrices.  This parser supports both formats.
+    """
+
+    edges = []
+
+    # First, look for ``x[s,i,j] = 1`` lines
     pattern = re.compile(r"x\[(\d+),(\d+),(\d+)\]\s*=\s*1")
-    edges = pattern.findall(ampl_text)
+    for s, i, j in pattern.findall(ampl_text):
+        edges.append((int(s), int(i), int(j)))
+
+    # If nothing found, attempt to parse matrix form "x [s,*,*]" printed by AMPL
+    if not edges:
+        lines = iter(ampl_text.splitlines())
+        for line in lines:
+            m = re.match(r"x\s*\[(\d+),\*,\*\]", line.strip())
+            if not m:
+                continue
+            s = int(m.group(1))
+
+            # Read header with column indices
+            header = next(lines, "")
+            cols = [int(n) for n in re.findall(r"-?\d+", header)]
+
+            for row in lines:
+                row = row.strip()
+                if not row or row.startswith("[") or row.startswith(";"):
+                    break
+                tokens = re.findall(r"-?\d+", row)
+                if len(tokens) != len(cols) + 1:
+                    continue
+                i = int(tokens[0])
+                vals = tokens[1:]
+                for col, val in zip(cols, vals):
+                    if val == "1":
+                        edges.append((s, i, col))
+
     if not edges:
         return []
-    edges = [(int(s), int(i), int(j)) for s, i, j in edges]
+
     salesmen = sorted({s for s, _, _ in edges})
     by_s = {s: {} for s in salesmen}
     for s, i, j in edges:
         by_s[s][i] = j
+
     city_map = {c.idx: c for c in cities}
     routes = []
     for s in salesmen:
@@ -40,6 +77,7 @@ def parse_ampl_routes(ampl_text, cities):
                 break
             current = nxt
         routes.append(route)
+
     return routes
 
 
@@ -76,12 +114,17 @@ def parse_lkh_tour(tour_file, cities):
 
 
 def run_ampl(output, csv_path):
-    # Ruta al ejecutable de AMPL
-    ampl_path = r"D:\DEV\AMPL\ampl.exe"
-    
-    # Verificar si el archivo ejecutable existe
-    if not os.path.exists(ampl_path):
-        append_output(output, f"Error: No se encontró el ejecutable de AMPL en {ampl_path}\n")
+    """Execute the AMPL model and display the resulting routes."""
+    # Allow configuration via the AMPL_PATH environment variable.  If not
+    # provided, fall back to searching ``ampl`` in the PATH.
+    ampl_path = os.environ.get("AMPL_PATH", "ampl")
+
+    # Verificar si el archivo ejecutable existe o está en PATH
+    if not shutil.which(ampl_path):
+        append_output(
+            output,
+            f"Error: No se encontró el ejecutable de AMPL ({ampl_path}).\n",
+        )
         return
     
     # Obtener la ruta base del proyecto
@@ -128,20 +171,26 @@ def run_ampl(output, csv_path):
             check=True
         )
         
-        # Mostrar resultados
+        # Mostrar resultados crudos
         append_output(output, "\n=== RESULTADOS DE AMPL ===\n")
         append_output(output, result.stdout)
-        
+
         if result.stderr:
             append_output(output, "\n=== ADVERTENCIAS ===\n")
             append_output(output, result.stderr)
-            
-        # Intentar cargar las ciudades y mostrar las rutas
+
+        # Cargar las ciudades y mostrar las rutas
         try:
             cities = load_cities(csv_path.get())
             routes = parse_ampl_routes(result.stdout, cities)
             if routes:
+                append_output(output, "\nRutas encontradas:\n")
+                for i, route in enumerate(routes, 1):
+                    path = " → ".join(str(c.idx) for c in route)
+                    append_output(output, f"Vendedor {i}: {path}\n")
                 plot_routes(routes)
+            else:
+                append_output(output, "No se pudieron interpretar rutas en la salida de AMPL\n")
         except Exception as e:
             append_output(output, f"\nError al mostrar las rutas: {str(e)}\n")
             


### PR DESCRIPTION
## Summary
- make AMPL path configurable via `AMPL_PATH` or PATH lookup
- parse AMPL `display x` output including matrix form
- show salesperson routes with arrows and plot them

## Testing
- `python -m py_compile python/gui.py`
- `python -m py_compile python/heuristica_bmtsp.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685096d0ea348323b0be13a7fcf81e39