### PR TITLE
Add route visualization and PDF export to notebook

### DIFF
--- a/jupiter/heuristica.ipynb
+++ b/jupiter/heuristica.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Heur\u00edstica BMTSP\n",
+    "Este notebook implementa una heur\u00edstica constructiva con mejora local para el Bounded Multiple Traveling Salesman Problem (BMTSP). Se usan los archivos CSV en `datos/` como conjunto de ciudades."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import csv\n",
+    "import math\n",
+    "import random\n",
+    "from dataclasses import dataclass"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "@dataclass\n",
+    "class City:\n",
+    "    idx: int\n",
+    "    x: float\n",
+    "    y: float\n\n",
+    "    def distance_to(self, other: \"City\") -> float:\n",
+    "        return math.hypot(self.x - other.x, self.y - other.y)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def load_cities(path):\n",
+    "    cities = []\n",
+    "    with open(path, newline=\"\") as f:\n",
+    "        reader = csv.DictReader(f)\n",
+    "        for row in reader:\n",
+    "            idx = int(row.get('id', row.get('idx')))\n",
+    "            cities.append(City(idx, float(row['x']), float(row['y'])))\n",
+    "    cities.sort(key=lambda c: c.idx)\n",
+    "    return cities"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def nearest_neighbor_route(cities, start):\n",
+    "    route = [start]\n",
+    "    remaining = cities[:]\n",
+    "    current = start\n",
+    "    while remaining:\n",
+    "        next_city = min(remaining, key=lambda c: current.distance_to(c))\n",
+    "        route.append(next_city)\n",
+    "        remaining.remove(next_city)\n",
+    "        current = next_city\n",
+    "    route.append(start)\n",
+    "    return route"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def route_length(route):\n",
+    "    return sum(route[i].distance_to(route[i+1]) for i in range(len(route)-1))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def two_opt(route):\n",
+    "    improved = True\n",
+    "    best = route\n",
+    "    while improved:\n",
+    "        improved = False\n",
+    "        for i in range(1, len(best) - 2):\n",
+    "            for j in range(i + 1, len(best) - 1):\n",
+    "                if j - i == 1:\n",
+    "                    continue\n",
+    "                new_route = best[:i] + best[i:j][::-1] + best[j:]\n",
+    "                if route_length(new_route) < route_length(best):\n",
+    "                    best = new_route\n",
+    "                    improved = True\n",
+    "        route = best\n",
+    "    return best"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def assign_cities(cities, k, max_ciudades):\n",
+    "    depot = cities[0]\n",
+    "    others = cities[1:]\n",
+    "    random.shuffle(others)\n",
+    "    ass = [[] for _ in range(k)]\n",
+    "    idx = 0\n",
+    "    for city in others:\n",
+    "        ass[idx % k].append(city)\n",
+    "        idx += 1\n",
+    "    for i in range(k):\n",
+    "        ass[i] = ass[i][:max_ciudades]\n",
+    "    return ass"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def heuristic_bmtsp(cities, k, max_ciudades):\n",
+    "    depot = cities[0]\n",
+    "    assignments = assign_cities(cities, k, max_ciudades)\n",
+    "    routes = []\n",
+    "    total_cost = 0.0\n",
+    "    for assigned in assignments:\n",
+    "        if not assigned:\n",
+    "            routes.append([depot, depot])\n",
+    "            continue\n",
+    "        route = nearest_neighbor_route(assigned, depot)\n",
+    "        route = two_opt(route)\n",
+    "        routes.append(route)\n",
+    "        total_cost += route_length(route)\n",
+    "    return routes, total_cost"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Ejemplo de ejecuci\u00f3n\n",
+    "csv_path = 'datos/ciudades_pequeno.csv'\n",
+    "k = 2\n",
+    "max_ciudades = 5\n",
+    "\n",
+    "cities = load_cities(csv_path)\n",
+    "routes, cost = heuristic_bmtsp(cities, k, max_ciudades)\n",
+    "print(f'Costo total: {cost:.2f}')\n",
+    "for i, route in enumerate(routes, 1):\n",
+    "    print(f'Vendedor {i}:', ' -> '.join(str(c.idx) for c in route))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.backends.backend_pdf import PdfPages"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def plot_routes(routes):\n",
+    "    colors=[f'C{i}' for i in range(len(routes))]\n",
+    "    fig, ax = plt.subplots()\n",
+    "    for idx,(color,route) in enumerate(zip(colors, routes),1):\n",
+    "        xs=[c.x for c in route]\n",
+    "        ys=[c.y for c in route]\n",
+    "        ax.plot(xs, ys, marker='o', color=color, label=f'Vendedor {idx}')\n",
+    "    ax.set_title('Rutas generadas por la heur\u00edstica')\n",
+    "    ax.legend()\n",
+    "    return fig"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "fig = plot_routes(routes)\n",
+    "plt.show()\n",
+    "fig.savefig('rutas.png')\n",
+    "with PdfPages('informe.pdf') as pdf:\n",
+    "    pdf.savefig(fig)\n",
+    "    plt.close(fig)\n",
+    "    fig2, ax2 = plt.subplots()\n",
+    "    ax2.axis('off')\n",
+    "    filas=[[i+1, len(r)-1, f'{route_length(r):.2f}'] for i,r in enumerate(routes)]\n",
+    "    ax2.table(cellText=filas, colLabels=['Vendedor','# Ciudades','Distancia'], loc='center')\n",
+    "    ax2.set_title(f'Costo total: {cost:.2f}')\n",
+    "    pdf.savefig(fig2)\n",
+    "    plt.close(fig2)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- extend `heuristica.ipynb` with code to plot the generated routes
- save the route map and metrics table into a PDF report

## Testing
- `python -m py_compile python/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6859c02173e48323966767f78d211118